### PR TITLE
chore: (main) release  @contensis/forms v1.0.0

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,1 +1,1 @@
-{}
+{"packages/react":"1.0.0"}

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -2,29 +2,4 @@
 
 ## 1.0.0 (2024-09-26)
 
-
-### Documentation
-
-* add new `onLoadError` prop to README ([5c85ede](https://github.com/contensis/contensis-forms/commit/5c85ede5a745fefb50f3422e8ddf85b2861097fc))
-* add README ([a938a91](https://github.com/contensis/contensis-forms/commit/a938a91de2b5f7c93013ad3d4aed426602f1042e))
-* update project READMEs, add simple README for trying out example apps ([510d455](https://github.com/contensis/contensis-forms/commit/510d455f776088cac68db10b3fdaa05cc38e84ff))
-
-
-### Features
-
-* add localised confirmation rules ([86fd0f9](https://github.com/contensis/contensis-forms/commit/86fd0f9aafd48af4fa8a7b2927e950fcb37b7885))
-* added date and time fields ([84b1e39](https://github.com/contensis/contensis-forms/commit/84b1e392266119435c369ba6961fb7d0ca5be406))
-* added form progress and updated date display ([b02f91f](https://github.com/contensis/contensis-forms/commit/b02f91f6fe37df826eb76bf3b8f7beef9edb5301))
-* added past date time validation ([b1e4036](https://github.com/contensis/contensis-forms/commit/b1e40365a6c3df071e6bb97da8f148c15e208f38))
-* added single field per page support ([edd1563](https://github.com/contensis/contensis-forms/commit/edd15639352806ddc13f95325258d3dfd91751f1))
-* initial components for forms rendering ([5aa0991](https://github.com/contensis/contensis-forms/commit/5aa09916ee7934c91fa4d68a32e426ee2beefd21))
-* removed dependency on management api ([2ee8289](https://github.com/contensis/contensis-forms/commit/2ee8289a7c1bdb23c95eba4f237b1ee4b9b0cf19))
-* update min/max count validations ([48f6941](https://github.com/contensis/contensis-forms/commit/48f6941a5eeeb02ce2c68c3a95f46ed516b52c4c))
-* updated auto saving and page navigation based on page rules ([3fa4e00](https://github.com/contensis/contensis-forms/commit/3fa4e000c84d8cea6345b29a0f521e361c1028db))
-* updated forward and back button behaviour ([cbce62a](https://github.com/contensis/contensis-forms/commit/cbce62ae4b74a3fad0890baa22fb499501078914))
-
-
-### Build
-
-* avoid `Can't resolve 'react/jsx-runtime'` error in consumer projects ([491d7ce](https://github.com/contensis/contensis-forms/commit/491d7ce78a193d2fc286c4f436c6e6b153b45ffb))
-* move `react` package dependencies to dev and specify `peerDepencies` to work with an existing installed react version ([d15e96f](https://github.com/contensis/contensis-forms/commit/d15e96fbe14baa96c012e1bd54d08aa30d773c10))
+Initial release

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+## 1.0.0 (2024-09-26)
+
+
+### Documentation
+
+* add new `onLoadError` prop to README ([5c85ede](https://github.com/contensis/contensis-forms/commit/5c85ede5a745fefb50f3422e8ddf85b2861097fc))
+* add README ([a938a91](https://github.com/contensis/contensis-forms/commit/a938a91de2b5f7c93013ad3d4aed426602f1042e))
+* update project READMEs, add simple README for trying out example apps ([510d455](https://github.com/contensis/contensis-forms/commit/510d455f776088cac68db10b3fdaa05cc38e84ff))
+
+
+### Features
+
+* add localised confirmation rules ([86fd0f9](https://github.com/contensis/contensis-forms/commit/86fd0f9aafd48af4fa8a7b2927e950fcb37b7885))
+* added date and time fields ([84b1e39](https://github.com/contensis/contensis-forms/commit/84b1e392266119435c369ba6961fb7d0ca5be406))
+* added form progress and updated date display ([b02f91f](https://github.com/contensis/contensis-forms/commit/b02f91f6fe37df826eb76bf3b8f7beef9edb5301))
+* added past date time validation ([b1e4036](https://github.com/contensis/contensis-forms/commit/b1e40365a6c3df071e6bb97da8f148c15e208f38))
+* added single field per page support ([edd1563](https://github.com/contensis/contensis-forms/commit/edd15639352806ddc13f95325258d3dfd91751f1))
+* initial components for forms rendering ([5aa0991](https://github.com/contensis/contensis-forms/commit/5aa09916ee7934c91fa4d68a32e426ee2beefd21))
+* removed dependency on management api ([2ee8289](https://github.com/contensis/contensis-forms/commit/2ee8289a7c1bdb23c95eba4f237b1ee4b9b0cf19))
+* update min/max count validations ([48f6941](https://github.com/contensis/contensis-forms/commit/48f6941a5eeeb02ce2c68c3a95f46ed516b52c4c))
+* updated auto saving and page navigation based on page rules ([3fa4e00](https://github.com/contensis/contensis-forms/commit/3fa4e000c84d8cea6345b29a0f521e361c1028db))
+* updated forward and back button behaviour ([cbce62a](https://github.com/contensis/contensis-forms/commit/cbce62ae4b74a3fad0890baa22fb499501078914))
+
+
+### Build
+
+* avoid `Can't resolve 'react/jsx-runtime'` error in consumer projects ([491d7ce](https://github.com/contensis/contensis-forms/commit/491d7ce78a193d2fc286c4f436c6e6b153b45ffb))
+* move `react` package dependencies to dev and specify `peerDepencies` to work with an existing installed react version ([d15e96f](https://github.com/contensis/contensis-forms/commit/d15e96fbe14baa96c012e1bd54d08aa30d773c10))

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contensis/forms",
-  "version": "1.0.0-beta.5",
+  "version": "1.0.0",
   "description": "Render Contensis Forms with React",
   "keywords": [
     "contensis",


### PR DESCRIPTION
:robot: Merge this PR to release a new version
---


## 1.0.0 (2024-09-26)

Initial release

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).