### PR TITLE
chore: (main) release  @contensis/forms v1.0.1

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,1 +1,1 @@
-{"packages/react":"1.0.0"}
+{"packages/react":"1.0.1"}

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.0.1](https://github.com/contensis/contensis-forms/compare/@contensis/forms-v1.0.0...@contensis/forms-v1.0.1) (2024-11-01)
+
+
+### Bug Fixes
+
+* require two back button presses to navigate back to previous page after a form has rendered ([bf166f4](https://github.com/contensis/contensis-forms/commit/bf166f455a10259e32363c70af4ee4aafcc60a1b))
+
 ## 1.0.0 (2024-09-26)
 
 Initial release

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contensis/forms",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Render Contensis Forms with React",
   "keywords": [
     "contensis",


### PR DESCRIPTION
:robot: Merge this PR to release a new version
---


## [1.0.1](https://github.com/contensis/contensis-forms/compare/@contensis/forms-v1.0.0...@contensis/forms-v1.0.1) (2024-11-01)


### Bug Fixes

* require two back button presses to navigate back to previous page after a form has rendered ([bf166f4](https://github.com/contensis/contensis-forms/commit/bf166f455a10259e32363c70af4ee4aafcc60a1b))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).