### PR TITLE
chore: (main) release  @contensis/forms v1.0.2

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,1 +1,1 @@
-{"packages/react":"1.0.1"}
+{"packages/react":"1.0.2"}

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.0.2](https://github.com/contensis/contensis-forms/compare/@contensis/forms-v1.0.1...@contensis/forms-v1.0.2) (2025-01-30)
+
+
+### Bug Fixes
+
+* Show/hide description and title when rendering in page. Hide describedBy if no instructions. ([e09f1cb](https://github.com/contensis/contensis-forms/commit/e09f1cb884a100bb7040f2ebb50a36753c5daaec))
+
 ## [1.0.1](https://github.com/contensis/contensis-forms/compare/@contensis/forms-v1.0.0...@contensis/forms-v1.0.1) (2024-11-01)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contensis/forms",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Render Contensis Forms with React",
   "keywords": [
     "contensis",


### PR DESCRIPTION
:robot: Merge this PR to release a new version
---


## [1.0.2](https://github.com/contensis/contensis-forms/compare/@contensis/forms-v1.0.1...@contensis/forms-v1.0.2) (2025-01-30)


### Bug Fixes

* Show/hide description and title when rendering in page. Hide describedBy if no instructions. ([e09f1cb](https://github.com/contensis/contensis-forms/commit/e09f1cb884a100bb7040f2ebb50a36753c5daaec))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).