### PR TITLE
fix: validation issue where the number of days in a month was miscalculated

### DIFF
--- a/packages/react/src/state/dates/date-utils.ts
+++ b/packages/react/src/state/dates/date-utils.ts
@@ -187,7 +187,7 @@ export function validateTimeParts(parts: TimeParts): TimeValidation {
 }
 
 function daysInMonth(year: number, month: number): number {
-    const date = new Date(year, month - 1, 1);
+    const date = new Date(year, month, 1);
     date.setDate(0);
     return date.getDate();
 }


### PR DESCRIPTION
The validation was failing on dates like "29-03-2025" because it was mistakenly believing 03 to be February. 
Just an off by one error. 
