### PR TITLE
chore: (main) release  @contensis/forms v1.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8380,7 +8380,7 @@
         },
         "packages/react": {
             "name": "@contensis/forms",
-            "version": "1.0.0-beta.5",
+            "version": "1.0.3",
             "license": "ISC",
             "dependencies": {
                 "markdown-it": "^14.0.0"

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.0.3](https://github.com/contensis/contensis-forms/compare/@contensis/forms-v1.0.2...@contensis/forms-v1.0.3) (2025-03-07)
+
+
+### Bug Fixes
+
+* fixes a validation issue where the number of days in a month was being miscalculated ([82fb47c](https://github.com/contensis/contensis-forms/commit/82fb47c9441359457ad507619400aad9003ef22d))
+* validation issue where the number of days in a month was miscalculated ([2048c5c](https://github.com/contensis/contensis-forms/commit/2048c5c592eb5243a3e4ef2eeea61649ccf96756))
+
 ## [1.0.2](https://github.com/contensis/contensis-forms/compare/@contensis/forms-v1.0.1...@contensis/forms-v1.0.2) (2025-01-30)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contensis/forms",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Render Contensis Forms with React",
   "keywords": [
     "contensis",


### PR DESCRIPTION
:robot: Merge this PR to release a new version
---


## [1.0.3](https://github.com/contensis/contensis-forms/compare/@contensis/forms-v1.0.2...@contensis/forms-v1.0.3) (2025-03-07)


### Bug Fixes

* fixes a validation issue where the number of days in a month was being miscalculated ([82fb47c](https://github.com/contensis/contensis-forms/commit/82fb47c9441359457ad507619400aad9003ef22d))
* validation issue where the number of days in a month was miscalculated ([2048c5c](https://github.com/contensis/contensis-forms/commit/2048c5c592eb5243a3e4ef2eeea61649ccf96756))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).