### PR TITLE
chore: release v1.0.4

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,1 +1,1 @@
-{"packages/react":"1.0.3"}
+{"packages/react":"1.0.4"}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8380,7 +8380,7 @@
         },
         "packages/react": {
             "name": "@contensis/forms",
-            "version": "1.0.3",
+            "version": "1.0.4",
             "license": "ISC",
             "dependencies": {
                 "markdown-it": "^14.0.0"

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.0.4](https://github.com/contensis/contensis-forms/compare/@contensis/forms-v1.0.3...@contensis/forms-v1.0.4) (2026-01-06)
+
+
+### Build
+
+* update CI workflows due to revoked NPM tokens and instead use NPM trusted publishing, fix package.json npm warnings ([a07f3e9](https://github.com/contensis/contensis-forms/commit/a07f3e9b1258473efc982ba3a2bb22c69d1ecc0b))
+
 ## [1.0.3](https://github.com/contensis/contensis-forms/compare/@contensis/forms-v1.0.2...@contensis/forms-v1.0.3) (2025-03-07)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contensis/forms",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Render Contensis Forms with React",
   "keywords": [
     "contensis",


### PR DESCRIPTION
:robot: Merge this PR to release a new version
---


## [1.0.4](https://github.com/contensis/contensis-forms/compare/@contensis/forms-v1.0.3...@contensis/forms-v1.0.4) (2026-01-06)


### Build

* update CI workflows due to revoked NPM tokens and instead use NPM trusted publishing, fix package.json npm warnings ([a07f3e9](https://github.com/contensis/contensis-forms/commit/a07f3e9b1258473efc982ba3a2bb22c69d1ecc0b))

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).