### PR TITLE
fix: Hydration error when used with SSR in React v18+

### DIFF
--- a/packages/react/src/components/Form.tsx
+++ b/packages/react/src/components/Form.tsx
@@ -18,12 +18,10 @@ import {
 } from './form-state';
 import { FormProps, SetFocussed, SetValue } from './models';
 
-function isServer() {
-    return typeof window === `undefined`;
-}
-
 export function ContensisForm(props: FormProps) {
-    return isServer() ? null : <ClientFormContainer {...props} />;
+    const [isClient, setIsClient] = useState(false);
+    useEffect(() => setIsClient(true), []);
+    return isClient ? <ClientFormContainer {...props} /> : null;
 }
 
 function ClientFormContainer(props: FormProps) {


### PR DESCRIPTION
Received this error during development with SSR - never noticed it before but it is also appearing [here](https://preview-17-1.cloud.contensis.com/form/applicationForm) (see minified error in console)

The fix is tried and tested and recommended in [React base 4](https://github.com/zengenti/contensis-react-base/blob/feat/react18/MIGRATE-V4.md#4-resolve-hydration-errors-with-client-rendering)

<img width="1916" height="1394" alt="image" src="https://github.com/user-attachments/assets/04a197d2-8cab-4c25-9030-be7904affec9" />
