### PR TITLE
chore: release v1.0.5

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,1 +1,1 @@
-{"packages/react":"1.0.4"}
+{"packages/react":"1.0.5"}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8380,7 +8380,7 @@
         },
         "packages/react": {
             "name": "@contensis/forms",
-            "version": "1.0.4",
+            "version": "1.0.5",
             "license": "ISC",
             "dependencies": {
                 "markdown-it": "^14.0.0"

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [1.0.5](https://github.com/contensis/contensis-forms/compare/@contensis/forms-v1.0.4...@contensis/forms-v1.0.5) (2026-04-29)
+
+
+### Bug Fixes
+
+* Hydration error when used with SSR in React v18+ ([#10](https://github.com/contensis/contensis-forms/issues/10)) ([fbf702d](https://github.com/contensis/contensis-forms/commit/fbf702de3e13c855e8f420cbe5173183b97f8996))
+* move focus to first field when paging through a form ([#12](https://github.com/contensis/contensis-forms/issues/12)) ([e522948](https://github.com/contensis/contensis-forms/commit/e5229483b13a396c549eed4574996e6dc1a8aed8)), closes [#11](https://github.com/contensis/contensis-forms/issues/11)
+
 ## [1.0.4](https://github.com/contensis/contensis-forms/compare/@contensis/forms-v1.0.3...@contensis/forms-v1.0.4) (2026-01-06)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contensis/forms",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Render Contensis Forms with React",
   "keywords": [
     "contensis",


### PR DESCRIPTION
:robot: Merge this PR to release a new version
---


## [1.0.5](https://github.com/contensis/contensis-forms/compare/@contensis/forms-v1.0.4...@contensis/forms-v1.0.5) (2026-04-29)


### Bug Fixes

* Hydration error when used with SSR in React v18+ ([#10](https://github.com/contensis/contensis-forms/issues/10)) ([fbf702d](https://github.com/contensis/contensis-forms/commit/fbf702de3e13c855e8f420cbe5173183b97f8996))
* move focus to first field when paging through a form ([#12](https://github.com/contensis/contensis-forms/issues/12)) ([e522948](https://github.com/contensis/contensis-forms/commit/e5229483b13a396c549eed4574996e6dc1a8aed8)), closes [#11](https://github.com/contensis/contensis-forms/issues/11)

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).